### PR TITLE
Add link to "model as data deployment" Medium article

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@
 67. [Continuous Machine Learning (CML) is CI/CD for Machine Learning Projects (DVC)](https://cml.dev/)
 68. [What I learned from looking at 200 machine learning tools](https://huyenchip.com/2020/06/22/mlops.html)
 69. [Big Data & AI Landscape](http://mattturck.com/wp-content/uploads/2018/07/Matt_Turck_FirstMark_Big_Data_Landscape_2018_Final.png)
+70. [Deploying Machine Learning Models as Data, not Code — A better match? MLOps using omega|ml](https://towardsdatascience.com/deploying-machine-learning-models-as-data-not-code-omega-ml-8825a0ae530a)
 
 
 


### PR DESCRIPTION
this is a contribution of a fresh conceptual idea, as implemented by the open-sourced omega|ml framework supporting MLOps for Pandas, Scikit-Learn, Tensorflow and other frameworks (disclaimer: I'm the original author of omega|ml)