### PR TITLE
Update - AI Canvas URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ A list of scientific and industrial papers and resources about Machine Learning 
 1. [Getting started with AI? Start here! Everything you need to know to dive into your project](https://medium.com/hackernoon/the-decision-makers-guide-to-starting-ai-72ee0d7044df)
 1. [11 questions to ask before starting a successful Machine Learning project](https://tryolabs.com/blog/2019/02/13/11-questions-to-ask-before-starting-a-successful-machine-learning-project/)
 1. [What AI still can’t do](https://www.technologyreview.com/s/615189/what-ai-still-cant-do/)
-1. [Demystifying AI Part 4: What is an AI Canvas and how do you use it?](https://thebrainfiles.wearebrain.com/demystifying-ai-part-4-what-is-an-ai-canvas-and-how-do-you-use-it-8899b9199a9)
+1. [Demystifying AI Part 4: What is an AI Canvas and how do you use it?](https://www.wearebrain.com/blog/ai-data-science/what-is-an-ai-canvas/)
 1. [A Data Science Workflow Canvas to Kickstart Your Projects](https://towardsdatascience.com/a-data-science-workflow-canvas-to-kickstart-your-projects-db62556be4d0)
 1. [Is your AI project a nonstarter? Here’s a reality check(list) to help you avoid the pain of learning the hard way](https://medium.com/hackernoon/ai-reality-checklist-be34e2fdab9)
 1. [What is THE main reason most ML projects fail?](https://towardsdatascience.com/what-is-the-main-reason-most-ml-projects-fail-515d409a161f)


### PR DESCRIPTION
I've updated the URL on the AI Canvas article under the section The Economics of ML/AI.