### PR TITLE
Adding coursera MLOps to "MLOps Courses"

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 # MLOps Courses
 
 1. [MLOps Zoomcamp (free)](https://github.com/DataTalksClub/mlops-zoomcamp)
+2. [Coursera's Machine Learning Engineering for Production (MLOps) Specialization](https://www.coursera.org/specializations/machine-learning-engineering-for-production-mlops)
 
 
 <a name="mlops-books"></a>


### PR DESCRIPTION
Adding coursera Machine Learning Engineering for Production (MLOps) Specialization to "MLOps Courses".
It is a general MLOps course not specific to any cloud provider. It uses mostly tensorflow modules in the (mostly optional) hands-on labs.