### PR TITLE
Make TOC Canonical

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![Twitter Follow](https://img.shields.io/twitter/follow/visenger?style=social)
 
 
-# Table of Content
+# Table of Contents
 | <!-- -->                         | <!-- -->                         |
 | -------------------------------- | -------------------------------- |
 | [MLOps Core](#core-mlops) | [MLOps Communities](#mlops-communities) |


### PR DESCRIPTION
Very minor issue: Updating to "Table of Contents" - pluralizing content is the canonical way to refer to this list. https://en.wikipedia.org/wiki/Table_of_contents