### PR TITLE
link finding label errors with cleanlab in DataOps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@
 1. [A curated list of awesome pipeline toolkits](https://github.com/pditommaso/awesome-pipeline)
 1. [Data Mesh Archtitecture](https://www.datamesh-architecture.com/)
 1. [The Essential Guide to Data Exploration in Machine Learning (by NimbleBox.ai)](https://nimblebox.ai/blog/data-exploration)
+1. [Finding millions of label errors with Cleanlab](https://datacentricai.org/blog/finding-millions-of-label-errors-with-cleanlab/)
 </details>
 
 


### PR DESCRIPTION
This same procedure has been used in many companies like Google, Amazon, Wells Fargo, etc. to find label errors in internal datasets.

It has also been featured in various media:
[[1](https://www.wired.com/story/foundations-ai-riddled-errors/), [2](https://www.technologyreview.com/2021/04/01/1021619/ai-data-errors-warp-machine-learning-progress/), [3](https://www.theregister.com/2021/04/01/mit_ai_accuracy/), [4](https://www.engadget.com/mit-datasets-ai-machine-learning-label-errors-040042574.html), [5](https://venturebeat.com/2021/03/28/mit-study-finds-systematic-labeling-errors-in-popular-ai-benchmark-datasets/), [6](https://www.csail.mit.edu/news/major-ml-datasets-have-tens-thousands-errors), [7](https://www.techtimes.com/articles/258516/20210329/mit-study-shows-labeling-errors-more-10-ai-testing-datasets.htm), [8](https://www.siliconrepublic.com/machines/mit-ai-datasets-errors)]
