### PR TITLE
Add Chain of Thought podcast to Talks About MLOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ A list of scientific and industrial papers and resources about Machine Learning 
 1. [Databricks' Data + AI Summit 2022](https://databricks.com/dataaisummit/north-america-2022)
 1. [RE•WORK MLOps Summit 2022](https://www.re-work.co/events/mlops-summit-2022)
 1. [Annual MLOps World Conference](https://mlopsworld.com/)
+1. [Chain of Thought](https://www.chainofthought.dev/) - Weekly conversations with AI leaders covering inference infrastructure, developer tools, MLOps, and AI strategy. Hosted by Conor Bronsdon.
 </details>
 
 <a name="existing-ml-systems"></a>

--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ A list of scientific and industrial papers and resources about Machine Learning 
 1. [Databricks' Data + AI Summit 2022](https://databricks.com/dataaisummit/north-america-2022)
 1. [RE•WORK MLOps Summit 2022](https://www.re-work.co/events/mlops-summit-2022)
 1. [Annual MLOps World Conference](https://mlopsworld.com/)
-1. [Chain of Thought](https://www.chainofthought.dev/) - Weekly conversations with AI leaders covering inference infrastructure, developer tools, MLOps, and AI strategy. Hosted by Conor Bronsdon.
+1. [Chain of Thought](https://chainofthought.show/) - Weekly conversations with AI leaders covering inference infrastructure, developer tools, MLOps, and AI strategy. Hosted by Conor Bronsdon.
 </details>
 
 <a name="existing-ml-systems"></a>


### PR DESCRIPTION
Adding [Chain of Thought](https://chainofthought.show/) to the Talks About MLOps section.

Chain of Thought is a weekly podcast that frequently covers MLOps topics including inference infrastructure, model deployment, developer tooling, and AI platform engineering. Guests have included leaders from OpenAI, Anthropic, NVIDIA, and companies building MLOps/AI infrastructure.

- Website: https://chainofthought.show/
- Available on Apple Podcasts, Spotify, YouTube
- Hosted by Conor Bronsdon