### PR TITLE
Add podcast to Talks About MLOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ A list of scientific and industrial papers and resources about Machine Learning 
 1. [Databricks' Data + AI Summit 2022](https://databricks.com/dataaisummit/north-america-2022)
 1. [RE•WORK MLOps Summit 2022](https://www.re-work.co/events/mlops-summit-2022)
 1. [Annual MLOps World Conference](https://mlopsworld.com/)
+1. [Chain of Thought](https://chainofthought.show/) - Weekly conversations with AI leaders covering inference infrastructure, developer tools, MLOps, and AI strategy.
 </details>
 
 <a name="existing-ml-systems"></a>


### PR DESCRIPTION
Adds Chain of Thought to the Talks About MLOps section. Weekly AI podcast that frequently covers MLOps topics including inference infrastructure, model deployment, and developer tooling.

https://chainofthought.show/