### PR TITLE
Add Falsify / PRML eval-audit article to Testing, Monitoring and Main…

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@
 1. [How to Trust Your Deep Learning Code](https://krokotsch.eu/cleancode/2020/08/11/Unit-Tests-for-Deep-Learning.html) ([Accompanying code](https://github.com/tilman151/unittest_dl))
 1. [Estimating Performance of Regression Models Without Ground-Truth](https://bit.ly/medium-estimating-performance-regression) (Using [NannyML](https://bit.ly/ml-ops-nannyml))
 1. [How Hyperparameter Tuning in Machine Learning Works (by NimbleBox.ai)](https://nimblebox.ai/blog/hyperparameter-tuning-machine-learning)
+1. [ML evaluation reproducibility audit — methodology + PRML pre-registration (Falsify / Studio 11)](https://spec.falsify.dev/reproducibility/eval-audit/)
 </details>
 
 <a name="mlops-infra"></a>


### PR DESCRIPTION
**Adding:** PRML — Pre-Registered ML Manifest (open spec) + `falsify` reference implementation.

**Why this fits Testing, Monitoring and Maintenance:** PRML pre-registers ML evaluation claims with a SHA-256 hash *before* the run, then verifies them in CI. The linked piece is a methodology article on running evaluation reproducibility audits — fits the section's article-driven format. Manifests are byte-equivalent across Python, JavaScript, Go, and Rust reference implementations.

**What it is:** Open specification (CC BY 4.0). A SHA-256 manifest binds metric, comparator, threshold, dataset hash, seed, and producer identity before the experiment runs. Verifier deterministically emits PASS (exit 0), FAIL (exit 10), TAMPERED (exit 3), or GUARD (exit 11).

**Status:** v0.1 published with Zenodo DOI [10.5281/zenodo.20177839](https://doi.org/10.5281/zenodo.20177839). SchemaStore catalog merged. GitHub Marketplace Action live ([`prml-verify`](https://github.com/marketplace/actions/prml-verify)). Four reference implementations all byte-equivalent on 20 conformance vectors. v0.2 RFC open through 2026-05-22.

**Maintainer:** Cüneyt Öztürk · Studio 11 — `hello@studio-11.co`