### PR TITLE
Add Inference Labs quickstart under Model Deployment and Serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@
 <summary>Click to expand!</summary>
  
 1. [AI Infrastructure for Everyone: DeterminedAI](https://determined.ai/)
+1. [Inference Labs Quickstart: vendor-neutral LLM routing in production](https://inference-labs.com/quickstart.html)
 1. [Deploying R Models with MLflow and Docker](https://mdneuzerling.com/post/deploying-r-models-with-mlflow-and-docker/)
 1. [What Does it Mean to Deploy a Machine Learning Model?](https://mlinproduction.com/what-does-it-mean-to-deploy-a-machine-learning-model-deployment-series-01/)
 1. [Software Interfaces for Machine Learning Deployment](https://mlinproduction.com/software-interfaces-for-machine-learning-deployment-deployment-series-02/)


### PR DESCRIPTION
Hi! This PR adds one deployment-focused resource under **MLOps: Model Deployment and Serving**.

Why it fits:

- Practical guide for running production LLM routing with policy controls.
- Focused on serving concerns: provider failover, cost/latency tradeoffs, and operational traces.
- Complements existing deployment resources in this section.

Happy to move or reword if another section is a better fit.