### PR TITLE
Add findcheck to Testing/Monitoring — findings-declaration validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,11 @@
 1. [How Hyperparameter Tuning in Machine Learning Works (by NimbleBox.ai)](https://nimblebox.ai/blog/hyperparameter-tuning-machine-learning)
 </details>
 
+1. [findcheck](https://github.com/patchwright/finding-declaration) — JSON Schema + validator for experiment FINDINGS (hypothesis verdicts: CONFIRMED/PARTIAL/REFUTED/INCONCLUSIVE/UNDECIDABLE); the verdict layer MLflow/W&B don't cover. `pip install findcheck`.
+
 <a name="mlops-infra"></a>
+
+
 # MLOps: Infrastructure & Tooling
 <details>
 <summary>Click to expand!</summary>


### PR DESCRIPTION
Adds **[findcheck](https://github.com/patchwright/finding-declaration)** under *Testing, Monitoring and Maintenance*.

A JSON Schema + validator for the experiment-FINDINGS layer (hypothesis verdicts: CONFIRMED/PARTIAL/REFUTED/INCONCLUSIVE/UNDECIDABLE) — the verdict layer that MLflow/W&B/DVC (verified across 40+ tracking tools + metadata standards) do not cover. Findings are the post-hoc verdict; metrics/params/artifacts are not. `pip install findcheck`, MIT, Python 3.10+.

Distinct from the testing articles already listed (which cover model/code testing): findcheck validates the *finding declaration* itself (the structured verdict a research run establishes).

- Repo: https://github.com/patchwright/finding-declaration
- PyPI: https://pypi.org/project/findcheck/